### PR TITLE
feat: add session (FIFO) send and receive sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Below is a quick summary of which samples included and what they are currently t
    * 2 producers are created on 2 different queues.
    * Message is sent to the 2nd producer through the first queue.
    * The scenario is validated by receiving from both queues to ensure the message lands in the same queue.
+
+### Queue - Session Send and Receive (FIFO)
+
+   * Queue must be created with sessions enabled (`requiresSession = true`) in the Azure portal or via ARM/Bicep.
+   * Set `Constants.SESSION_QUEUE` to the name of your session-enabled queue (default: `sessionqueue`).
+   * 10 messages are sent across 3 session IDs (`session-A`, `session-B`, `session-C`).
+   * Messages are received per session, demonstrating FIFO ordering within each session.

--- a/src/main/java/com/microsoft/azure/samples/QueueSessionSendReceive.java
+++ b/src/main/java/com/microsoft/azure/samples/QueueSessionSendReceive.java
@@ -1,0 +1,127 @@
+package com.microsoft.azure.samples;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.ExceptionListener;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+
+import org.apache.qpid.jms.JmsQueue;
+
+import com.microsoft.azure.samples.util.ConnectionHelper;
+import com.microsoft.azure.samples.util.Constants;
+
+/**
+ * Demonstrates sending and receiving session-aware messages on an Azure Service
+ * Bus queue using JMS 2.0. Messages within the same session are delivered in
+ * FIFO order; different sessions are independent of each other.
+ *
+ * Prerequisites:
+ *   - The queue referenced by Constants.SESSION_QUEUE must be created with
+ *     sessions enabled (requiresSession = true) in the Azure portal or via
+ *     ARM/Bicep. This cannot be configured through JMS.
+ */
+public class QueueSessionSendReceive {
+    private static final int DELIVERY_MODE = DeliveryMode.PERSISTENT;
+    private static final int MESSAGES_PER_SESSION = 10;
+    private static final String[] SESSION_IDS = {"session-A", "session-B", "session-C"};
+
+    public static void main(String[] args) throws Exception {
+        try {
+            /*
+             * Initialize the JMS Connection and Session.
+             */
+            ConnectionFactory factory = ConnectionHelper.createConnectionFactory();
+            Connection connection = factory.createConnection();
+
+            connection.setExceptionListener(new MyExceptionListener());
+            connection.start();
+
+            Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+
+            // The queue must be created with sessions enabled in the Azure portal.
+            // For example: "sessionqueue" (configured with requiresSession = true).
+            JmsQueue queue = new JmsQueue(Constants.SESSION_QUEUE);
+
+            /*
+             * Sending — distribute messages across three session IDs.
+             * Setting JMSXGroupID assigns each message to a session.
+             */
+            MessageProducer producer = session.createProducer(queue);
+            int totalSent = 0;
+
+            long start = System.currentTimeMillis();
+            for (String sessionId : SESSION_IDS) {
+                for (int i = 1; i <= MESSAGES_PER_SESSION; i++) {
+                    TextMessage message = session.createTextMessage(
+                            "Session [" + sessionId + "] message " + i);
+                    message.setStringProperty("JMSXGroupID", sessionId);
+                    producer.send(message, DELIVERY_MODE, Message.DEFAULT_PRIORITY,
+                            Message.DEFAULT_TIME_TO_LIVE);
+                    totalSent++;
+                }
+                System.out.println("Sent " + MESSAGES_PER_SESSION
+                        + " messages to session [" + sessionId + "]");
+            }
+            long taken = System.currentTimeMillis() - start;
+            System.out.println("Sent " + totalSent + " messages across "
+                    + SESSION_IDS.length + " sessions in " + taken + "ms");
+            System.out.println();
+
+            /*
+             * Receiving — create consumers that receive from the session-enabled
+             * queue. The broker assigns the next available session to each
+             * consumer. Messages within a session arrive in FIFO order.
+             */
+            for (int s = 0; s < SESSION_IDS.length; s++) {
+                MessageConsumer consumer = session.createConsumer(queue);
+
+                System.out.println("Receiving from session " + (s + 1)
+                        + " of " + SESSION_IDS.length + " ...");
+
+                int received = 0;
+                start = System.currentTimeMillis();
+
+                while (true) {
+                    Message message = consumer.receive(2000);
+                    if (message == null) {
+                        break;
+                    }
+                    received++;
+                    if (message instanceof TextMessage) {
+                        String body = ((TextMessage) message).getText();
+                        String receivedSessionId = message.getStringProperty("JMSXGroupID");
+                        System.out.println("  [" + receivedSessionId + "] " + body);
+                    }
+                    message.acknowledge();
+                }
+                taken = System.currentTimeMillis() - start - 2000;
+                System.out.println("Received " + received + " messages in "
+                        + Math.max(taken, 0) + "ms");
+                System.out.println();
+
+                consumer.close();
+            }
+
+            connection.close();
+            System.out.println("Done.");
+        } catch (Exception exp) {
+            System.out.println("Caught exception, exiting.");
+            exp.printStackTrace(System.out);
+            System.exit(1);
+        }
+    }
+
+    private static class MyExceptionListener implements ExceptionListener {
+        public void onException(JMSException exception) {
+            System.out.println("Connection ExceptionListener fired, exiting.");
+            exception.printStackTrace(System.out);
+            System.exit(1);
+        }
+    }
+}

--- a/src/main/java/com/microsoft/azure/samples/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/samples/util/Constants.java
@@ -9,5 +9,6 @@ public class Constants {
     public static final String SERVICE_BUS_CONNECTION_STRING = null; // e.g. "Endpoint=sb://..."
 
     public static final String QUEUE = "testqueue";
+    public static final String SESSION_QUEUE = "sessionqueue"; // Must be created with sessions enabled (requiresSession = true)
     public static final String TOPIC = "testtopic";
 }


### PR DESCRIPTION
## Session (FIFO) Send and Receive Sample

Adds a new JMS sample demonstrating session-aware messaging on Azure Service Bus.

### What this adds

- **`QueueSessionSendReceive.java`** — standalone console sample that:
  - Sends 10 messages across 3 session IDs (`session-A`, `session-B`, `session-C`) using `JMSXGroupID`
  - Receives messages per session, demonstrating FIFO ordering within each session
  - Uses `ConnectionHelper.createConnectionFactory()` (supports both Entra ID and connection string auth)
- **`Constants.SESSION_QUEUE`** — new constant for the session-enabled queue name (default: `sessionqueue`)
- **README.md** — added sample description and prerequisites

### Prerequisites

The queue must be created with **sessions enabled** (`requiresSession = true`) in the Azure portal or via ARM/Bicep. This cannot be configured programmatically through JMS.

### Customer context

Requested by a customer (CACI, Feb 2023) who needed to configure `topicJmsListenerContainerFactory` for session-enabled queues and topics. No sample existed at the time.

### Testing

- [x] Compiles with `mvn compile`
- [ ] Live testing against a Premium namespace with a session-enabled queue
