### PR TITLE
feat: add scheduled messages sample using JMS 2.0 setDeliveryDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Below is a quick summary of which samples included and what they are currently t
    * 1 message (which satisfies the selector conditions) is received.
    * The remaining 9 messages can be browsed using the [Service Bus Explorer](https://docs.microsoft.com/azure/service-bus-messaging/explorer).
 
+### Queue - Scheduled Messages
+
+   * 1 immediate message and 1 scheduled message (30s delay) are sent.
+   * Messages are received, showing the scheduled message arrives after the delay.
+   * Uses JMS 2.0 `setDeliveryDelay()` API.
+   * **Requires Azure Service Bus Premium tier.**
+
 ### Cross entity Transactioned Send
 
    * Transacted session is created

--- a/src/main/java/com/microsoft/azure/samples/QueueScheduledSend.java
+++ b/src/main/java/com/microsoft/azure/samples/QueueScheduledSend.java
@@ -83,7 +83,7 @@ public class QueueScheduledSend {
              *
              * getJMSDeliveryTime() returns the earliest time the message
              * becomes deliverable — for the scheduled message this will be
-             * approximately sendTime + deliveryDelay.
+             * approximately scheduledSendTime + DELIVERY_DELAY_MS.
              */
             MessageConsumer consumer = session.createConsumer(queue);
 
@@ -93,8 +93,6 @@ public class QueueScheduledSend {
                     System.out.println("[" + Instant.now() + "] No message received within timeout.");
                     break;
                 }
-                received.acknowledge();
-
                 String body = (received instanceof TextMessage)
                         ? ((TextMessage) received).getText()
                         : received.toString();
@@ -104,6 +102,8 @@ public class QueueScheduledSend {
                 if (deliveryTime > 0) {
                     System.out.println("  JMSDeliveryTime: " + Instant.ofEpochMilli(deliveryTime));
                 }
+
+                received.acknowledge();
             }
 
             consumer.close();

--- a/src/main/java/com/microsoft/azure/samples/QueueScheduledSend.java
+++ b/src/main/java/com/microsoft/azure/samples/QueueScheduledSend.java
@@ -1,0 +1,126 @@
+package com.microsoft.azure.samples;
+
+import java.time.Instant;
+
+import jakarta.jms.Connection;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.Destination;
+import jakarta.jms.ExceptionListener;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+
+import org.apache.qpid.jms.JmsQueue;
+
+import com.microsoft.azure.samples.util.ConnectionHelper;
+import com.microsoft.azure.samples.util.Constants;
+
+/**
+ * Demonstrates sending scheduled messages using the JMS 2.0 delivery delay API
+ * with Azure Service Bus. One message is sent immediately and another with a
+ * 30-second delivery delay. The consumer receives both and prints timestamps
+ * showing that the scheduled message arrives after the delay period.
+ *
+ * <p><strong>Requires Azure Service Bus Premium tier.</strong></p>
+ */
+public class QueueScheduledSend {
+    private static final int DELIVERY_MODE = DeliveryMode.PERSISTENT;
+    private static final long DELIVERY_DELAY_MS = 30_000; // 30 seconds
+    private static final int RECEIVE_TIMEOUT_MS = 60_000; // 60 seconds
+
+    public static void main(String[] args) throws Exception {
+        try {
+            /*
+             * Initialize the JMS Connection and Session.
+             */
+            ConnectionFactory factory = ConnectionHelper.createConnectionFactory();
+            Connection connection = factory.createConnection();
+
+            Destination queue = new JmsQueue(Constants.QUEUE);
+
+            connection.setExceptionListener(new MyExceptionListener());
+            connection.start();
+
+            Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+
+            /*
+             * Send an immediate message (no delivery delay).
+             */
+            MessageProducer producer = session.createProducer(queue);
+
+            TextMessage immediateMessage = session.createTextMessage("Immediate message");
+            producer.send(immediateMessage, DELIVERY_MODE, Message.DEFAULT_PRIORITY, Message.DEFAULT_TIME_TO_LIVE);
+            Instant sendTime = Instant.now();
+            System.out.println("[" + sendTime + "] Sent immediate message.");
+
+            /*
+             * Send a scheduled message with a 30-second delivery delay.
+             * JMS 2.0 setDeliveryDelay() maps to the Service Bus scheduled
+             * enqueue time. The message becomes visible to consumers only
+             * after the delay period elapses.
+             */
+            producer.setDeliveryDelay(DELIVERY_DELAY_MS);
+
+            TextMessage scheduledMessage = session.createTextMessage("Scheduled message (30s delay)");
+            producer.send(scheduledMessage, DELIVERY_MODE, Message.DEFAULT_PRIORITY, Message.DEFAULT_TIME_TO_LIVE);
+            Instant scheduledSendTime = Instant.now();
+            Instant expectedDelivery = scheduledSendTime.plusMillis(DELIVERY_DELAY_MS);
+            System.out.println("[" + scheduledSendTime + "] Sent scheduled message.");
+            System.out.println("  Delivery delay: " + DELIVERY_DELAY_MS + " ms");
+            System.out.println("  Expected delivery after: " + expectedDelivery);
+            System.out.println();
+            System.out.println("Waiting for messages (the scheduled message will arrive after ~30s)...");
+
+            producer.close();
+
+            /*
+             * Receive both messages. The immediate message should arrive first.
+             * The scheduled message should arrive after the delivery delay.
+             *
+             * getJMSDeliveryTime() returns the earliest time the message
+             * becomes deliverable — for the scheduled message this will be
+             * approximately sendTime + deliveryDelay.
+             */
+            MessageConsumer consumer = session.createConsumer(queue);
+
+            for (int i = 1; i <= 2; i++) {
+                Message received = consumer.receive(RECEIVE_TIMEOUT_MS);
+                if (received == null) {
+                    System.out.println("[" + Instant.now() + "] No message received within timeout.");
+                    break;
+                }
+                received.acknowledge();
+
+                String body = (received instanceof TextMessage)
+                        ? ((TextMessage) received).getText()
+                        : received.toString();
+
+                long deliveryTime = received.getJMSDeliveryTime();
+                System.out.println("[" + Instant.now() + "] Received: " + body);
+                if (deliveryTime > 0) {
+                    System.out.println("  JMSDeliveryTime: " + Instant.ofEpochMilli(deliveryTime));
+                }
+            }
+
+            consumer.close();
+            session.close();
+            connection.close();
+        } catch (Exception exp) {
+            System.out.println("Caught exception, exiting.");
+            exp.printStackTrace(System.out);
+            System.exit(1);
+        }
+    }
+
+    private static class MyExceptionListener implements ExceptionListener {
+        public void onException(JMSException exception) {
+            System.out.println("Connection ExceptionListener fired, exiting.");
+            exception.printStackTrace(System.out);
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Scheduled Messages Sample

Adds a new sample demonstrating how to send messages scheduled for future delivery using the JMS 2.0 `setDeliveryDelay()` API with Azure Service Bus.

### What this sample does

1. Sends an immediate message (no delivery delay)
2. Sends a scheduled message with a 30-second delivery delay using `producer.setDeliveryDelay(30_000)`
3. Receives both messages, printing timestamps and `JMSDeliveryTime` to show the delay was honored

### Key points

- `setDeliveryDelay()` maps to the Service Bus **scheduled enqueue time** property
- Requires **Azure Service Bus Premium tier**
- The sample prints expected delivery time at send time and `getJMSDeliveryTime()` on receive for visual confirmation

### Files changed

- **New:** `src/main/java/com/microsoft/azure/samples/QueueScheduledSend.java`
- **Modified:** `README.md` (added sample description)

### Verification

- Compiles successfully with `mvn clean compile`
- API usage matches JMS 2.0 spec and the [JMS feature list](https://learn.microsoft.com/azure/service-bus-messaging/how-to-use-java-message-service-20#jms-20-features) which confirms Delivery Delay is supported

### Related

- Requested in [azure-sdk-for-java#21532](https://github.com/Azure/azure-sdk-for-java/issues/21532)
- Companion docs PR adds a section to the JMS developer guide
